### PR TITLE
refactor: update default checkmk_agent_version from 2.0.0p25 to v2.0.0p26 :arrow_up:

### DIFF
--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -68,7 +68,7 @@ Must *not* end with an `/`.
 
 [source,yaml]
 ----
-checkmk_agent_version: "2.0.0p25"
+checkmk_agent_version: "2.0.0p26"
 ----
 #Must be supplied#.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 
 # as in 'checkmk_server' role
 # ===== BEGIN generate_yaml MANAGED SECTION
-checkmk_agent_version: 2.0.0p25
+checkmk_agent_version: 2.0.0p26
 # ===== END generate_yaml MANAGED SECTION
 
 checkmk_agent_url: "{{


### PR DESCRIPTION
:robot: Authored by `__scripts/ci.py` python script on airtop-jonas by jonas from Vienna  

 *Release Date of v2.0.0p26: 2022-06-20*
*GitHub Compare URL (for the interested):* https://github.com/tribe29/checkmk/compare/v2.0.0p25...v2.0.0p26

 

 **This PR should result in the release of a new minor version for this role**!

NOTE: There have been **12** new versions since 2.0.0p25. After this PR has been merged, the github workflow will run again and a new PR will open semi-immideally. Please ensure to create a proper tag/release for **every** merged ci.py PR.

---
Accompanying `ansible-role-checkmk_server` PR: https://github.com/JonasPammer/ansible-role-checkmk_server/pull/10