### PR TITLE
refactor: update default checkmk_agent_version from 2.0.0p26 to v2.0.0p27 :arrow_up:

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,7 @@ Must *not* end with an `/`.
 
 [source,yaml]
 ----
-checkmk_agent_version: "2.0.0p26"
+checkmk_agent_version: "2.0.0p27"
 ----
 #Must be supplied#.
 

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -68,7 +68,7 @@ Must *not* end with an `/`.
 
 [source,yaml]
 ----
-checkmk_agent_version: "2.0.0p26"
+checkmk_agent_version: "2.0.0p27"
 ----
 #Must be supplied#.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 
 # as in 'checkmk_server' role
 # ===== BEGIN generate_yaml MANAGED SECTION
-checkmk_agent_version: 2.0.0p26
+checkmk_agent_version: 2.0.0p27
 # ===== END generate_yaml MANAGED SECTION
 
 checkmk_agent_url: "{{


### PR DESCRIPTION
:robot: *Authored by `__scripts/ci.py` python script on fv-az462-167 by runner from Des Moines*  

 *Release Date of v2.0.0p27: 2022-07-19*
*GitHub Compare URL (for the interested):* https://github.com/tribe29/checkmk/compare/v2.0.0p26...v2.0.0p27

 

**This PR should result in the release of a new minor version for this role**! Please use the following link as a starting point for creating the new release (ensure to **click on this link *after* merging this PR**): 
> https://github.com/JonasPammer/ansible-role-checkmk_agent/releases/new?tag=1.0.2&target=master&title=update%20default%20to%20v2.0.0p27&body=Accompanying%20%60ansible-role-checkmk_server%60%20release%3A%20%5B2.0.3%5D%28https%3A%2F%2Fgithub.com%2FJonasPammer%2Fansible-role-checkmk_server%2Freleases%2Ftag%2F2.0.3%29 

NOTE: There have been **12** new versions since 2.0.0p26. After this PR has been merged, the github workflow will run again and a new PR will open semi-immideally. Please ensure to create a proper tag/release for **every** merged ci.py PR.

---
Accompanying `ansible-role-checkmk_server` PR: https://github.com/JonasPammer/ansible-role-checkmk_server/pull/20