### PR TITLE
refactor: update default checkmk_agent_version from 2.0.0p27 to v2.1.0 :arrow_up:

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -97,7 +97,7 @@ Must *not* end with an `/`.
 
 [source,yaml]
 ----
-checkmk_agent_version: "2.0.0p27"
+checkmk_agent_version: "2.0.0p28"
 ----
 #Must be supplied#.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ URL to a CheckMk site that uses the same version as `checkmk_agent_version`. Mus
 
 _Must be supplied_ if `checkmk_agent_url` is not supplied by yourself.
 
-    checkmk_agent_version: "2.0.0p27"
+    checkmk_agent_version: "2.0.0p28"
 
 _Must be supplied_.
 

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -69,7 +69,7 @@ Must *not* end with an `/`.
 
 [source,yaml]
 ----
-checkmk_agent_version: "2.0.0p27"
+checkmk_agent_version: "2.0.0p28"
 ----
 #Must be supplied#.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 
 # as in 'checkmk_server' role
 # ===== BEGIN generate_yaml MANAGED SECTION
-checkmk_agent_version: 2.0.0p27
+checkmk_agent_version: 2.0.0p28
 # ===== END generate_yaml MANAGED SECTION
 
 checkmk_agent_url: "{{


### PR DESCRIPTION
:robot: *Authored by `__scripts/ci.py` python script on fv-az399-924 by runner from Washington*  

 *Release Date of v2.1.0: 2022-05-22*
*GitHub Compare URL (for the interested):* https://github.com/tribe29/checkmk/compare/v2.0.0p27...v2.1.0

 

**This PR should result in the release of a new minor version for this role**! Please use the following link as a starting point for creating the new release (ensure to **click on this link *after* merging this PR**): 
> https://github.com/JonasPammer/ansible-role-checkmk_agent/releases/new?tag=1.0.3&target=master&title=update%20default%20to%20v2.1.0&body=Accompanying%20%60ansible-role-checkmk_server%60%20release%3A%20%5B2.0.4%5D%28https%3A//github.com/JonasPammer/ansible-role-checkmk_server/releases/tag/2.0.4%25%29 

NOTE: There have been **11** new versions since 2.0.0p27. After this PR has been merged, the github workflow will run again and a new PR will open semi-immideally. Please ensure to create a proper tag/release for **every** merged ci.py PR.

---
Accompanying `ansible-role-checkmk_server` PR: https://github.com/JonasPammer/ansible-role-checkmk_server/pull/21