### PR TITLE
ci: make seperate container for checkmk_server

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -196,7 +196,16 @@ which sources its soft dependencies from `requirements.yml`:
 ----
 ---
 - name: prepare
-  hosts: all
+  hosts: all,!checkmk_server
+  become: true
+  gather_facts: false
+
+  roles:
+    - role: jonaspammer.bootstrap
+    - role: jonaspammer.core_dependencies
+
+- name: prepare checkmk_server
+  hosts: checkmk_server
   become: true
   gather_facts: false
 

--- a/README.adoc
+++ b/README.adoc
@@ -204,6 +204,8 @@ which sources its soft dependencies from `requirements.yml`:
     - role: jonaspammer.bootstrap
     - role: jonaspammer.core_dependencies
 
+# NOTE: only needed for testing!
+#       this play is not needed for prepararation of checkmk_agent provisioning :)
 - name: prepare checkmk_server
   hosts: checkmk_server
   become: true

--- a/README.adoc
+++ b/README.adoc
@@ -196,7 +196,7 @@ which sources its soft dependencies from `requirements.yml`:
 ----
 ---
 - name: prepare
-  hosts: all,!checkmk_server
+  hosts: all,!checkmk-server
   become: true
   gather_facts: false
 
@@ -206,8 +206,8 @@ which sources its soft dependencies from `requirements.yml`:
 
 # NOTE: only needed for testing!
 #       this play is not needed for prepararation of checkmk_agent provisioning :)
-- name: prepare checkmk_server
-  hosts: checkmk_server
+- name: prepare checkmk-server
+  hosts: checkmk-server
   become: true
   gather_facts: false
 
@@ -229,16 +229,18 @@ requirements.yml dependency graph of jonaspammer.checkmk_agent]
 ====
 [source,yaml]
 ----
+---
 roles:
   - role: jonaspammer.checkmk_agent
 
 vars:
-  checkmk_site_url: "http://srvcmk.intra.yoursite.com/master"
   checkmk_agent_version: 2.0.0p25
+  checkmk_site_url: "http://srvcmk.intra.yoursite.com/master"
 ----
 
 [source,yaml]
 ----
+---
 roles:
   - role: jonaspammer.checkmk_agent
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The machine needs to be prepared. In CI, this is done in `molecule/resources/pre
 
     ---
     - name: prepare
-      hosts: all,!checkmk_server
+      hosts: all,!checkmk-server
       become: true
       gather_facts: false
 
@@ -137,8 +137,8 @@ The machine needs to be prepared. In CI, this is done in `molecule/resources/pre
 
     # NOTE: only needed for testing!
     #       this play is not needed for prepararation of checkmk_agent provisioning :)
-    - name: prepare checkmk_server
-      hosts: checkmk_server
+    - name: prepare checkmk-server
+      hosts: checkmk-server
       become: true
       gather_facts: false
 
@@ -151,13 +151,15 @@ The following diagram is a compilation of the "soft dependencies" of this role a
 
 ![requirements.yml dependency graph of jonaspammer.checkmk_agent](https://raw.githubusercontent.com/JonasPammer/ansible-roles/master/graphs/dependencies_checkmk_agent.svg)
 
+    ---
     roles:
       - role: jonaspammer.checkmk_agent
 
     vars:
-      checkmk_site_url: "http://srvcmk.intra.yoursite.com/master"
       checkmk_agent_version: 2.0.0p25
+      checkmk_site_url: "http://srvcmk.intra.yoursite.com/master"
 
+    ---
     roles:
       - role: jonaspammer.checkmk_agent
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,16 @@ The machine needs to be prepared. In CI, this is done in `molecule/resources/pre
 
     ---
     - name: prepare
-      hosts: all
+      hosts: all,!checkmk_server
+      become: true
+      gather_facts: false
+
+      roles:
+        - role: jonaspammer.bootstrap
+        - role: jonaspammer.core_dependencies
+
+    - name: prepare checkmk_server
+      hosts: checkmk_server
       become: true
       gather_facts: false
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ The machine needs to be prepared. In CI, this is done in `molecule/resources/pre
         - role: jonaspammer.bootstrap
         - role: jonaspammer.core_dependencies
 
+    # NOTE: only needed for testing!
+    #       this play is not needed for prepararation of checkmk_agent provisioning :)
     - name: prepare checkmk_server
       hosts: checkmk_server
       become: true

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -181,16 +181,18 @@ requirements.yml dependency graph of jonaspammer.checkmk_agent]
 ====
 [source,yaml]
 ----
+---
 roles:
   - role: jonaspammer.checkmk_agent
 
 vars:
-  checkmk_site_url: "http://srvcmk.intra.yoursite.com/master"
   checkmk_agent_version: 2.0.0p25
+  checkmk_site_url: "http://srvcmk.intra.yoursite.com/master"
 ----
 
 [source,yaml]
 ----
+---
 roles:
   - role: jonaspammer.checkmk_agent
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,5 +2,8 @@
 - name: Converge
   hosts: all,!checkmk-server
 
+  vars:
+    checkmk_site_url: "http://checkmk-server/main"
+
   roles:
     - role: "ansible-role-checkmk_agent"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,6 +1,6 @@
 ---
 - name: Converge
-  hosts: all,!checkmk_server
+  hosts: all,!checkmk-server
 
   roles:
     - role: "ansible-role-checkmk_agent"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,9 +1,6 @@
 ---
 - name: Converge
-  hosts: all
-
-  vars:
-    checkmk_agent_version: "{{ checkmk_server_version }}"
+  hosts: all,!checkmk_server
 
   roles:
     - role: "ansible-role-checkmk_agent"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,6 +19,15 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
+  # service-enabled Docker image by geerlingguy
+  - name: checkmk_server
+    image: "geerlingguy/docker-ubuntu2204-ansible:latest"
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,7 +20,7 @@ platforms:
     privileged: true
     pre_build_image: true
   # service-enabled Docker image by geerlingguy
-  - name: checkmk_server
+  - name: checkmk-server
     image: "geerlingguy/docker-ubuntu2204-ansible:latest"
     command: ""
     volumes:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,6 +19,8 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
+    networks:
+      - name: molecule-checkmk
   # service-enabled Docker image by geerlingguy
   - name: checkmk-server
     image: "geerlingguy/docker-ubuntu2204-ansible:latest"
@@ -28,6 +30,8 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
+    networks:
+      - name: molecule-checkmk
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: output some generally helpful debug information about the provisioned machine
-  hosts: all,!checkmk_server
+  hosts: all,!checkmk-server
   become: true
   gather_facts: true
 
@@ -10,6 +10,6 @@
 
 ### Actual Role Verification Tasks:
 - name: Verify
-  hosts: all,!checkmk_server
+  hosts: all,!checkmk-server
 
   tasks:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,6 +1,6 @@
 ---
 - name: output some generally helpful debug information about the provisioned machine
-  hosts: all
+  hosts: all,!checkmk_server
   become: true
   gather_facts: true
 
@@ -10,6 +10,6 @@
 
 ### Actual Role Verification Tasks:
 - name: Verify
-  hosts: all
+  hosts: all,!checkmk_server
 
   tasks:

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -8,6 +8,8 @@
     - role: jonaspammer.bootstrap
     - role: jonaspammer.core_dependencies
 
+# NOTE: only needed for testing!
+#       this play is not needed for prepararation of checkmk_agent provisioning :)
 - name: prepare checkmk_server
   hosts: checkmk_server
   become: true

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -1,6 +1,6 @@
 ---
 - name: prepare
-  hosts: all,!checkmk_server
+  hosts: all,!checkmk-server
   become: true
   gather_facts: false
 
@@ -10,8 +10,8 @@
 
 # NOTE: only needed for testing!
 #       this play is not needed for prepararation of checkmk_agent provisioning :)
-- name: prepare checkmk_server
-  hosts: checkmk_server
+- name: prepare checkmk-server
+  hosts: checkmk-server
   become: true
   gather_facts: false
 

--- a/molecule/resources/prepare.yml
+++ b/molecule/resources/prepare.yml
@@ -1,6 +1,15 @@
 ---
 - name: prepare
-  hosts: all
+  hosts: all,!checkmk_server
+  become: true
+  gather_facts: false
+
+  roles:
+    - role: jonaspammer.bootstrap
+    - role: jonaspammer.core_dependencies
+
+- name: prepare checkmk_server
+  hosts: checkmk_server
   become: true
   gather_facts: false
 


### PR DESCRIPTION
server only supports a smaller more defined set of distro's.
agent works on more (if not everyone you can think of i'd assume).

untested, and will definetily not work fully yet.
because checkmk_agent converge now doesnt automatigally has checkmk_servers variables (which it never shouldve had praxis-wise)
i need to figure out what to set `checkmk_site_url` to, i.e. in what way can the agent container talk to the server container and what may i need to additionally configure in molecule.yml for that to work

<!-- Insert Description here, if any. -->

## **Pull Request Checklist**

- [ ] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->
- [ ] This pull request and its commits address only a single concern
- [ ] Documentation has been altered or extended appropriately

- [ ] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
